### PR TITLE
apt install fasttree mafft

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,9 @@ ENV LC_ALL C.UTF-8
 # Install required packages
 RUN apt-get update && \
     apt-get install -y \
+    fasttree \
     gcc \
+    mafft \
     python3 \
     bwa \
     samtools \
@@ -50,21 +52,6 @@ RUN wget https://github.com/rrwick/Porechop/archive/refs/tags/v0.2.4.tar.gz && \
     rm v0.2.4.tar.gz && \
     cd Porechop-0.2.4 && \
     python3 setup.py install
-
-# Install MAAFT
-RUN wget https://mafft.cbrc.jp/alignment/software/mafft-7.475-with-extensions-src.tgz && \
-    tar -zxvf mafft-7.475-with-extensions-src.tgz && \
-    rm mafft-7.475-with-extensions-src.tgz && \
-    cd mafft-7.475-with-extensions/core && \
-    make && \
-    mv mafft /usr/local/bin
-
-
-
-# Install FastTree
-RUN wget http://www.microbesonline.org/fasttree/FastTree && \
-    chmod +x FastTree && \
-    mv FastTree /usr/local/bin/
 
 # Download SILVA138.1
 RUN wget https://www.arb-silva.de/fileadmin/silva_databases/release_138_1/Exports/SILVA_138.1_SSURef_tax_silva.fasta.gz && \


### PR DESCRIPTION
seems cleaner?
- use the package library,
- apt install list should be sorted alphabetically