### PR TITLE
Single barcode experiment handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,15 +218,12 @@ snakemake \
 
 ![Workflow](config/workflow.png)
 
+**NB: NanOASV is able to handle a single barcode experiment. It still needs a metadata file with two lines (header and data). Results will be produced as a one sample phyloseq object and a classical CSV for quick lookup.**
 
 ## Data preparation
 
 Directly input your `/path/to/sequence/data/fastq_pass` directory
 4000 sequences `fastq.gz` files are concatenated by barcode identity to make one `barcodeXX.fastq.gz` file.
-
-### Single barcode experiment
-
-Note that NanOASV is able to handle a single barcode experiment. It still needs a metadata file with two lines (header and data). Results will be produced as a one sample phyloseq object and a classical CSV for quick lookup.
 
 ## Filtering
 

--- a/README.md
+++ b/README.md
@@ -224,6 +224,10 @@ snakemake \
 Directly input your `/path/to/sequence/data/fastq_pass` directory
 4000 sequences `fastq.gz` files are concatenated by barcode identity to make one `barcodeXX.fastq.gz` file.
 
+### Single barcode experiment
+
+Note that NanOASV is able to handle a single barcode experiment. It still needs a metadata file with two lines (header and data). Results will be produced as a one sample phyloseq object and a classical CSV for quick lookup.
+
 ## Filtering
 
 Chopper will filter for inappropriate sequences.

--- a/README.md
+++ b/README.md
@@ -218,12 +218,15 @@ snakemake \
 
 ![Workflow](config/workflow.png)
 
-**NB: NanOASV is able to handle a single barcode experiment. It still needs a metadata file with two lines (header and data). Results will be produced as a one sample phyloseq object and a classical CSV for quick lookup.**
 
 ## Data preparation
 
 Directly input your `/path/to/sequence/data/fastq_pass` directory
 4000 sequences `fastq.gz` files are concatenated by barcode identity to make one `barcodeXX.fastq.gz` file.
+
+#### About single barcode experiment
+
+Note that NanoASV is able to handle a single barcode experiment. You need to put your fastq file in a directory named ```barcode01``` and it still needs a metadata file with two lines (header and data). Results will be produced as usual. A one sample phyloseq object and a classical CSV for quick lookup.
 
 ## Filtering
 

--- a/workflow/scripts/script.r
+++ b/workflow/scripts/script.r
@@ -157,16 +157,23 @@ for (i in 1:length(temp_ASV)) {
   physeq_list[[barcode_name]] <- physeq_object
 }
 
-i<-1 #Reset the incrementation
-#Initialize the phyloseq object
-NanoASV <- phyloseq::merge_phyloseq(physeq_list[[i]], physeq_list[[i + 1]])
-
-# If more than 2 samples, then, adding them all together
-if (length(physeq_list) > 2) {
-  for (i in 3:length(physeq_list)) {
-    NanoASV <- phyloseq::merge_phyloseq(NanoASV, physeq_list[[i]])
+if (length(physeq_list) > 1) {
+  
+  i<-1 #Reset the incrementation
+  #Initialize the phyloseq object
+  NanoASV <- phyloseq::merge_phyloseq(physeq_list[[i]], physeq_list[[i + 1]])
+  
+  # If more than 2 samples, then, adding them all together
+  if (length(physeq_list) > 2) {
+    for (i in 3:length(physeq_list)) {
+      NanoASV <- phyloseq::merge_phyloseq(NanoASV, physeq_list[[i]])
+    }
   }
+} else {
+  #If only one sample, it's first object of the list.
+  NanoASV <- physeq_list[[1]]
 }
+
 
 ##Phylogeny ----
 if(TREE == 1){


### PR DESCRIPTION
NanoASV can now handle single barcode experiment. 
It still needs to have a barcode like structure, even though there are no barcode _per se_. A metadata file with two lines (header and data) is still expected.