### PR TITLE
Update environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: NanoASV
 channels:
   - conda-forge
   - bioconda
-  - defaults
+  - nodefaults
 dependencies:
   - _libgcc_mutex=0.1=conda_forge
   - _openmp_mutex=4.5=2_gnu


### PR DESCRIPTION
replace "defaults" channel to "nodefaults" for switching from Anaconda to conda-forge. Indeed, Anaconda is not free of use anymore (the channel is sometime ban from several organization).

We should do several tests to be sure that all packages are installed with this modification.
